### PR TITLE
fix(eslint): use prettier rule from recommended

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -359,18 +359,6 @@ export const config = {
 		'vars-on-top': 'off',
 		yoda: 'error',
 		'simple-import-sort/sort': 'error',
-		'prettier/prettier': [
-			'error',
-			{
-				arrowParens: 'avoid',
-				printWidth: 100,
-				semi: true,
-				singleQuote: true,
-				tabWidth: 4,
-				trailingComma: 'none',
-				useTabs: true
-			}
-		],
 		'array-callback-return': 'off',
 		'@typescript-eslint/explicit-member-accessibility': 'off',
 		'@typescript-eslint/prefer-for-of': 'off',


### PR DESCRIPTION
### Description:

`plugin:prettier/recommended` already sets `prettier/prettier` to `error` which is the recommended configuration by eslint-plugin-prettier. It then reads the prettier config in the repo for getting the prettier rules to apply (or the defaults of prettier).

Also by forcing reliance on a `.prettierrc` file means that when you run Prettier (`--write` or `--check`) manually (as in, not via eslint, for example as "on save" action in VSCode) it applies the same rules as when running with linter.

### Changes:

- Removed prettier overwrite rule from eslint config

### Confirm Changes
-  [x] I have tested all my changes thoroughly.
